### PR TITLE
Updating rand dependency to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,5 +90,5 @@ std = [
     "serde/std"
 ]
 u64_digit = []
-prime = ["rand"]
+prime = ["rand/std_rng"]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-authors = ["dignifiedquire <dignifiedquire@gmail.com>", "The Rust Project Developers"]
+authors = [
+    "dignifiedquire <dignifiedquire@gmail.com>",
+    "The Rust Project Developers"
+]
 description = "Big integer implementation for Rust"
 documentation = "https://docs.rs/num-bigint-dig"
 homepage = "https://github.com/dignifiedquire/num-bigint"
 keywords = ["mathematics", "numerics", "bignum"]
-categories = [ "algorithms", "data-structures", "science" ]
+categories = ["algorithms", "data-structures", "science"]
 license = "MIT/Apache-2.0"
 name = "num-bigint-dig"
 repository = "https://github.com/dignifiedquire/num-bigint"
@@ -36,7 +39,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "0.7"
+version = "0.8.3"
 default-features = false
 
 [dependencies.zeroize]
@@ -65,10 +68,10 @@ version = "1.2.7"
 default-features = false
 
 [dev-dependencies]
-rand_chacha = "0.2"
-rand_xorshift = "0.2"
-rand_isaac = "0.2"
-rand = { version = "0.7", features = ["small_rng"] }
+rand_chacha = "0.3"
+rand_xorshift = "0.3"
+rand_isaac = "0.3"
+rand = { version = "0.8", features = ["small_rng"] }
 
 [dev-dependencies.serde_test]
 version = "1.0"
@@ -79,7 +82,13 @@ autocfg = "0.1.5"
 [features]
 default = ["std", "i128", "u64_digit"]
 i128 = ["num-integer/i128", "num-traits/i128"]
-std = ["num-integer/std", "num-traits/std", "smallvec/write", "rand/std", "serde/std"]
+std = [
+    "num-integer/std",
+    "num-traits/std",
+    "smallvec/write",
+    "rand/std",
+    "serde/std"
+]
 u64_digit = []
 prime = ["rand"]
 nightly = []

--- a/benchmark_crate/Cargo.toml
+++ b/benchmark_crate/Cargo.toml
@@ -12,8 +12,8 @@ name = "bench_main"
 num-bigint-dig = { path = "../", features = ["prime", "rand"] }
 num-integer = "0.1.39"
 num-traits = "0.2.4"
-rand = "0.7"
-rand_chacha = "0.2"
+rand = "0.8.3"
+rand_chacha = "0.3.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/tests/torture.rs
+++ b/tests/torture.rs
@@ -10,13 +10,16 @@ use rand::prelude::*;
 
 fn test_mul_divide_torture_count(count: usize) {
     let bits_max = 1 << 12;
-    let seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let seed = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
     let mut rng = rand::rngs::SmallRng::from_seed(seed);
 
     for _ in 0..count {
         // Test with numbers of random sizes:
-        let xbits = rng.gen_range(0, bits_max);
-        let ybits = rng.gen_range(0, bits_max);
+        let xbits = rng.gen_range(0..bits_max);
+        let ybits = rng.gen_range(0..bits_max);
 
         let x = rng.gen_biguint(xbits);
         let y = rng.gen_biguint(ybits);


### PR DESCRIPTION
This updates the `rand` dependency to `0.8`

Note that in this updated version of `rand`, implementors of `SeedableRng` are responsible for making the results little-endian (eg https://github.com/rust-random/rand/blob/50c34064c80762ddae11447adc6240f42a6bd266/src/rng.rs#L357), so I've also removed the extra call to `to_le()`