### PR TITLE
Don't panic if autocfg probe fails

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,7 @@ use std::env;
 fn main() {
     let ac = autocfg::new();
 
-    if ac.probe_type("i128") {
+    if ac.probe_type("i128") || env::var_os("CARGO_FEATURE_I128").is_some() {
         println!("cargo:rustc-cfg=has_i128");
-    } else if env::var_os("CARGO_FEATURE_I128").is_some() {
-        panic!("i128 support was not detected!");
     }
 }


### PR DESCRIPTION
Motivation: [autocfg panics when building with `-Zbuild-std`][1].

Instead of panicking when the `i128` feature is requested but
`probe_type("i128")` fails, just go ahead and enable the feature. If
`i128` truly isn't available then compilation will still fail, just
later on. This is unlikely to be an issue in practice since [`i128`
was stabilized in Rust 1.26.0][2].

Tested by building with:

    cargo +nightly build --target=x86_64-unknown-uefi \
        -Zbuild-std=core,alloc --no-default-features \
        --features=i128

I imagine that since the [readme lists compatibility starting with rustc 1.31][3], the `i128` feature could probably be dropped entirely, but I figure this more minimal change is easier.

[1]: https://github.com/cuviper/autocfg/issues/34
[2]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1260-2018-05-10
[3]: https://github.com/rust-num/num-bigint#compatibility