### PR TITLE
Unconditionally set has_i128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,12 @@ default-features = false
 [dependencies.num-integer]
 version = "0.1.39"
 default-features = false
+features = [ "i128" ]
 
 [dependencies.num-traits]
 version = "0.2.4"
 default-features = false
+features = [ "i128" ]
 
 [dependencies.num-iter]
 version = "0.1.37"
@@ -76,12 +78,9 @@ rand = { version = "0.8", features = ["small_rng"] }
 [dev-dependencies.serde_test]
 version = "1.0"
 
-[build-dependencies]
-autocfg = "1.0"
-
 [features]
-default = ["std", "i128", "u64_digit"]
-i128 = ["num-integer/i128", "num-traits/i128"]
+default = ["std", "u64_digit"]
+i128 = []
 std = [
     "num-integer/std",
     "num-traits/std",

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,3 @@
-extern crate autocfg;
-use std::env;
-
 fn main() {
-    let ac = autocfg::new();
-
-    if ac.probe_type("i128") || env::var_os("CARGO_FEATURE_I128").is_some() {
-        println!("cargo:rustc-cfg=has_i128");
-    }
+    println!("cargo:rustc-cfg=has_i128");
 }


### PR DESCRIPTION
Because `num-bigint-dig` sets a MSRV higher than 1.26, which enables the `i128` primitive type, this PR unconditionally enables this feature.