### PR TITLE
Impl `zeroize` without using `zeroize_derive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ default-features = false
 version = "1.1.0"
 default-features = false
 optional = true
-features = ["zeroize_derive"]
 
 [dependencies.serde]
 optional = true

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -128,7 +128,6 @@ impl<'de> serde::Deserialize<'de> for Sign {
 
 /// A big signed integer type.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct BigInt {
     pub(crate) sign: Sign,
     pub(crate) data: BigUint,
@@ -193,6 +192,14 @@ impl Default for BigInt {
     #[inline]
     fn default() -> BigInt {
         Zero::zero()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for BigInt {
+    fn zeroize(&mut self) {
+        self.sign.zeroize();
+        self.data.zeroize();
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -91,7 +91,6 @@ use UsizePromotion;
 
 /// A big unsigned integer type.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct BigUint {
     pub(crate) data: SmallVec<[BigDigit; VEC_SIZE]>,
 }
@@ -131,6 +130,13 @@ impl Default for BigUint {
     #[inline]
     fn default() -> BigUint {
         Zero::zero()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for BigUint {
+    fn zeroize(&mut self) {
+        self.data.as_mut().zeroize();
     }
 }
 


### PR DESCRIPTION
The `zeroize_derive` crate has quite a few dependencies, and in particular `syn` is a fairly large one with not-insignificant compile times.

The usages of `zeroize` are fairly trivial with two impls zeroing a total of three fields, which makes them easy to write by hand.

It takes more crate dependencies for the proc macro to do that (`proc-macro2`, `quote`, `syn`, `synstructure`, and `zeroize_derive` itself) than there are fields being zeroized, so I think it makes sense to ditch the additional dependencies and write these impls by hand.