### PR TITLE
Improved `Zeroize` impl for `BigInt`'s `Sign`

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -53,13 +53,14 @@ pub enum Sign {
     Plus,
 }
 
-#[cfg(feature = "zeroize")]
-impl Zeroize for Sign {
-    fn zeroize(&mut self) {
-        // TODO: Figure out how to better clear the sign.
-        *self = Sign::NoSign;
+impl Default for Sign {
+    fn default() -> Sign {
+        Sign::NoSign
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Sign {}
 
 impl Neg for Sign {
     type Output = Sign;


### PR DESCRIPTION
The `zeroize` crate defines a blanket impl of `Zeroize` for any type with the `DefaultIsZeroes` marker trait, which replaces the value with its `Default` using volatile writes with a memory fence.

This does require defining `Default` on `Sign`, but it seems like `Sign::NoSign` is a fairly reasonable choice for a default.