### PR TITLE
Arbitrary support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ autobenches = false
 [package.metadata.docs.rs]
 features = ["std", "serde", "rand", "prime"]
 
-[dependencies]
+[dependencies.arbitrary]
+version = "1.1.0"
+optional = true
 
 [dependencies.smallvec]
 version = "1.0.0"
@@ -82,6 +84,7 @@ version = "1.0"
 
 [features]
 default = ["std", "u64_digit"]
+fuzz = ["arbitrary", "smallvec/arbitrary"]
 i128 = []
 std = [
     "num-integer/std",

--- a/src/algorithms/div.rs
+++ b/src/algorithms/div.rs
@@ -1,6 +1,6 @@
+use core::cmp::Ordering;
 use num_traits::{One, Zero};
 use smallvec::SmallVec;
-use core::cmp::Ordering;
 
 use crate::algorithms::{add2, cmp_slice, sub2};
 use crate::big_digit::{self, BigDigit, DoubleBigDigit};

--- a/src/algorithms/gcd.rs
+++ b/src/algorithms/gcd.rs
@@ -3,9 +3,9 @@ use crate::bigint::Sign::*;
 use crate::bigint::{BigInt, ToBigInt};
 use crate::biguint::{BigUint, IntDigits};
 use crate::integer::Integer;
-use num_traits::{One, Signed, Zero};
 use alloc::borrow::Cow;
 use core::ops::Neg;
+use num_traits::{One, Signed, Zero};
 
 /// XGCD sets z to the greatest common divisor of a and b and returns z.
 /// If extended is true, XGCD returns their value such that z = a*x + b*y.

--- a/src/algorithms/jacobi.rs
+++ b/src/algorithms/jacobi.rs
@@ -97,5 +97,4 @@ mod tests {
             assert_eq!(case[2] as isize, jacobi(&x, &y), "jacobi({}, {})", x, y);
         }
     }
-
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3311,6 +3311,20 @@ impl<'a, 'b> ExtendedGcd<&'b BigUint> for &'a BigInt {
     }
 }
 
+// arbitrary support
+#[cfg(feature = "fuzz")]
+impl arbitrary::Arbitrary<'_> for BigInt {
+    fn arbitrary(src: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let sign = if bool::arbitrary(src)? {
+            Sign::Plus
+        } else {
+            Sign::Minus
+        };
+        let data = BigUint::arbitrary(src)?;
+        Ok(Self { sign, data })
+    }
+}
+
 #[test]
 fn test_from_biguint() {
     fn check(inp_s: Sign, inp_n: usize, ans_s: Sign, ans_n: usize) {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -3321,7 +3321,7 @@ impl arbitrary::Arbitrary<'_> for BigInt {
             Sign::Minus
         };
         let data = BigUint::arbitrary(src)?;
-        Ok(Self { sign, data })
+        Ok(Self::from_biguint(sign, data))
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -3382,3 +3382,12 @@ fn test_set_digit() {
     assert_eq!(a.data.len(), 1);
     assert_eq!(a.data[0], 4);
 }
+
+// arbitrary support
+#[cfg(feature = "fuzz")]
+impl arbitrary::Arbitrary<'_> for BigUint {
+    fn arbitrary(src: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let data = SmallVec::arbitrary(src)?;
+        Ok(Self { data })
+    }
+}

--- a/src/monty.rs
+++ b/src/monty.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::many_single_char_names)]
 
-use num_traits::{One, Zero};
-use core::ops::Shl;
 use alloc::vec::Vec;
+use core::ops::Shl;
+use num_traits::{One, Zero};
 
 use crate::big_digit::{self, BigDigit, DoubleBigDigit, SignedDoubleBigDigit};
 use crate::biguint::BigUint;

--- a/tests/biguint.rs
+++ b/tests/biguint.rs
@@ -20,8 +20,7 @@ use std::{i128, u128};
 use std::{u16, u32, u64, u8, usize};
 
 use num_traits::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow,
-    ToPrimitive, Zero,
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow, ToPrimitive, Zero,
 };
 
 use num_traits::float::FloatCore;


### PR DESCRIPTION
Adds [`arbitrary::Arbitrary`](https://docs.rs/arbitrary/1.1.0/arbitrary/trait.Arbitrary.html) support for the `BigInt` and `BigUint` types (gated behind the `fuzz` feature flag)