### PR TITLE
Convert lazy_static to an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,6 @@ features = [ "alloc" ]
 [dependencies.libm]
 version = "0.2.1"
 
-[dependencies.lazy_static]
-version = "1.2.0"
-default-features = false
-# no_std feature is an anti-pattern. Why, lazy_static, why?
-# See https://github.com/rust-lang-nursery/lazy-static.rs/issues/150
-features = ["spin_no_std"]
-
 [dev-dependencies]
 rand_chacha = "0.3"
 rand_xorshift = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,9 +89,7 @@ std = [
     "smallvec/write",
     "rand/std",
     "serde/std",
-    "lazy_static"
 ]
 u64_digit = []
 prime = ["rand/std_rng"]
 nightly = []
-lazy_static = ["dep:lazy_static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["algorithms", "data-structures", "science"]
 license = "MIT/Apache-2.0"
 name = "num-bigint-dig"
 repository = "https://github.com/dignifiedquire/num-bigint"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.56"
 readme = "README.md"
@@ -62,6 +62,14 @@ features = [ "alloc" ]
 [dependencies.libm]
 version = "0.2.1"
 
+[dependencies.lazy_static]
+version = "1.2.0"
+default-features = false
+# no_std feature is an anti-pattern. Why, lazy_static, why?
+# See https://github.com/rust-lang-nursery/lazy-static.rs/issues/150
+features = ["spin_no_std"]
+optional = true
+
 [dev-dependencies]
 rand_chacha = "0.3"
 rand_xorshift = "0.3"
@@ -72,7 +80,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 version = "1.0"
 
 [features]
-default = ["std", "u64_digit"]
+default = ["std", "u64_digit","lazy_static"]
 fuzz = ["arbitrary", "smallvec/arbitrary"]
 i128 = []
 std = [
@@ -80,8 +88,10 @@ std = [
     "num-traits/std",
     "smallvec/write",
     "rand/std",
-    "serde/std"
+    "serde/std",
+    "lazy_static"
 ]
 u64_digit = []
 prime = ["rand/std_rng"]
 nightly = []
+lazy_static = ["dep:lazy_static"]


### PR DESCRIPTION
Lazy_static is not compatible with thumbv6m-none-eabi targets. It prevents the use of this library with many microcontrollers, such as the Raspberry Pi Pico. To address this issue, I converted lazy_static to an optional dependency and included it in the default features.