### PR TITLE
Fix future incompatibility warning

### DIFF
--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -1,7 +1,7 @@
 #[allow(deprecated, unused_imports)]
 use alloc::borrow::Cow;
 use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::cmp::Ordering::{self, Equal, Greater, Less};
 use core::default::Default;
 use core::hash::{Hash, Hasher};


### PR DESCRIPTION
Fixes:

```
error: macro `vec` is private
   --> src/biguint.rs:490:22
    |
490 |         BigUint::new(vec![1])
    |                      ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #120192 <https://github.com/rust-lang/rust/issues/120192>
    = note: `#[deny(private_macro_use)]` on by default
```