### PR TITLE
Update to rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "0.8.3"
+version = "0.9"
 default-features = false
 
 [dependencies.zeroize]
@@ -66,10 +66,10 @@ version = "0.2.1"
 version = "1"
 
 [dev-dependencies]
-rand_chacha = "0.3"
-rand_xorshift = "0.3"
-rand_isaac = "0.3"
-rand = { version = "0.8", features = ["small_rng"] }
+rand_chacha = "0.9"
+rand_xorshift = "0.4"
+rand_isaac = "0.4"
+rand = { version = "0.9", features = ["small_rng"] }
 
 [dev-dependencies.serde_test]
 version = "1.0"

--- a/src/bigrand.rs
+++ b/src/bigrand.rs
@@ -1,7 +1,7 @@
 //! Randomization of big integers
 
 use alloc::vec;
-use rand::distributions::uniform::{SampleBorrow, SampleUniform, UniformSampler};
+use rand::distr::uniform::{self, SampleBorrow, SampleUniform, UniformSampler};
 use rand::prelude::*;
 use rand::Rng;
 
@@ -71,12 +71,12 @@ impl<R: Rng + ?Sized> RandBigInt for R {
                 // again with probability 0.5. This is because otherwise,
                 // the probability of generating a zero BigInt would be
                 // double that of any other number.
-                if self.gen() {
+                if self.random() {
                     continue;
                 } else {
                     NoSign
                 }
-            } else if self.gen() {
+            } else if self.random() {
                 Plus
             } else {
                 Minus
@@ -129,7 +129,7 @@ impl UniformSampler for UniformBigUint {
     type X = BigUint;
 
     #[inline]
-    fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+    fn new<B1, B2>(low_b: B1, high_b: B2) -> Result<Self, uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
@@ -139,14 +139,14 @@ impl UniformSampler for UniformBigUint {
 
         assert!(low < high);
 
-        UniformBigUint {
+        Ok(UniformBigUint {
             len: high - low,
             base: low.clone(),
-        }
+        })
     }
 
     #[inline]
-    fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
+    fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Result<Self, uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
@@ -160,7 +160,7 @@ impl UniformSampler for UniformBigUint {
     }
 
     #[inline]
-    fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
+    fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Result<Self::X, uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
@@ -168,7 +168,7 @@ impl UniformSampler for UniformBigUint {
         let low = low_b.borrow();
         let high = high_b.borrow();
 
-        rng.gen_biguint_range(low, high)
+        Ok(rng.gen_biguint_range(low, high))
     }
 }
 
@@ -187,7 +187,7 @@ impl UniformSampler for UniformBigInt {
     type X = BigInt;
 
     #[inline]
-    fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+    fn new<B1, B2>(low_b: B1, high_b: B2) -> Result<Self, uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
@@ -196,14 +196,14 @@ impl UniformSampler for UniformBigInt {
         let high = high_b.borrow();
 
         assert!(low < high);
-        UniformBigInt {
+        Ok(UniformBigInt {
             len: into_magnitude(high - low),
             base: low.clone(),
-        }
+        })
     }
 
     #[inline]
-    fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
+    fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Result<Self, uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
@@ -221,7 +221,7 @@ impl UniformSampler for UniformBigInt {
     }
 
     #[inline]
-    fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
+    fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Result<Self::X, uniform::Error>
     where
         B1: SampleBorrow<Self::X> + Sized,
         B2: SampleBorrow<Self::X> + Sized,
@@ -229,7 +229,7 @@ impl UniformSampler for UniformBigInt {
         let low = low_b.borrow();
         let high = high_b.borrow();
 
-        rng.gen_bigint_range(low, high)
+        Ok(rng.gen_bigint_range(low, high))
     }
 }
 
@@ -275,10 +275,10 @@ impl Distribution<BigInt> for RandomBits {
 /// extern crate rand;
 /// extern crate num_bigint_dig as num_bigint;
 ///
-/// use rand::thread_rng;
+/// use rand::rng;
 /// use num_bigint::RandPrime;
 ///
-/// let mut rng = thread_rng();
+/// let mut rng = rng();
 /// let p = rng.gen_prime(1024);
 /// assert_eq!(p.bits(), 1024);
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! # fn main() {
 //! use bigint::{ToBigInt, RandBigInt};
 //!
-//! let mut rng = rand::thread_rng();
+//! let mut rng = rand::rng();
 //! let a = rng.gen_bigint(1000);
 //!
 //! let low = -10000.to_bigint().unwrap();

--- a/tests/bigint.rs
+++ b/tests/bigint.rs
@@ -1121,22 +1121,22 @@ fn test_negative_shr() {
 #[cfg(feature = "rand")]
 fn test_random_shr() {
     #[cfg(feature = "std")]
-    fn thread_rng() -> impl rand::Rng {
-        rand::thread_rng()
+    fn rng() -> impl rand::Rng {
+        rand::rng()
     }
     #[cfg(not(feature = "std"))]
-    fn thread_rng() -> impl rand::Rng {
+    fn rng() -> impl rand::Rng {
         use rand::SeedableRng;
         // Chosen by fair dice roll
         rand::rngs::StdRng::seed_from_u64(4)
     }
 
-    use rand::distributions::Standard;
+    use rand::distr::StandardUniform;
     use rand::Rng;
 
-    let rng = thread_rng();
+    let rng = rng();
 
-    for p in rng.sample_iter::<i64, _>(&Standard).take(1000) {
+    for p in rng.sample_iter::<i64, _>(&StandardUniform).take(1000) {
         let big = BigInt::from(p);
         let bigger = &big << 1000;
         assert_eq!(&bigger >> 1000, big);

--- a/tests/roots.rs
+++ b/tests/roots.rs
@@ -105,22 +105,22 @@ mod biguint {
     #[test]
     fn test_roots_rand() {
         #[cfg(feature = "std")]
-        fn thread_rng() -> impl rand::Rng {
-            rand::thread_rng()
+        fn rng() -> impl rand::Rng {
+            rand::rng()
         }
         #[cfg(not(feature = "std"))]
-        fn thread_rng() -> impl rand::Rng {
+        fn rng() -> impl rand::Rng {
             use rand::SeedableRng;
             // Chosen by fair dice roll
             rand::rngs::StdRng::seed_from_u64(4)
         }
 
         use crate::num_bigint::RandBigInt;
-        use rand::distributions::Uniform;
+        use rand::distr::Uniform;
         use rand::Rng;
 
-        let rng = &mut thread_rng();
-        let bit_range = Uniform::new(0, 2048);
+        let rng = &mut rng();
+        let bit_range = Uniform::new(0, 2048).unwrap();
         let sample_bits: Vec<_> = rng.sample_iter(&bit_range).take(100).collect();
         for bits in sample_bits {
             let x = rng.gen_biguint(bits);


### PR DESCRIPTION
This updates rand and rand_ crates to latest versions.

`thread_rng` is renamed to `rng` in tests and function docs to match the renaming in rand 0.9.